### PR TITLE
fix: 🐛 transformArrayToMap fieldsArray may undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-99.44%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-98.85%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-99.02%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-99.41%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-99.44%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-98.62%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-99.02%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-99.41%25-brightgreen.svg?style=flat) |
 
 
 ## 1. Introduction

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-99.44%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-98.62%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-99.02%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-99.41%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-99.44%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-98.85%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-99.02%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-99.41%25-brightgreen.svg?style=flat) |
 
 
 ## 1. Introduction

--- a/src/util/transform.js
+++ b/src/util/transform.js
@@ -141,7 +141,7 @@ export function transformArrayToMap(inputType, origin) {
     if (resolvedType && origin !== null && origin !== undefined) {
       if (origin[name] && Array.isArray(origin[name])) {
         const {
-          fieldsArray,
+          fieldsArray = [],
           fields: resolvedFields,
           options: resolvedOptions = {},
         } = resolvedType;

--- a/test/unit/util/token.proto.json
+++ b/test/unit/util/token.proto.json
@@ -207,6 +207,21 @@
           "id": 2
         }
       }
+    },
+    "TestEnum": {
+      "values": {
+        "EMAIL": 0,
+        "PHONE": 1
+      }
+    },
+    "TestEnumArray": {
+      "fields": {
+        "type": {
+          "rule": "repeated",
+          "type": "TestEnum",
+          "id": 1
+        }
+      }
     }
   }
 }

--- a/test/unit/util/transform.test.js
+++ b/test/unit/util/transform.test.js
@@ -74,7 +74,7 @@ describe('test httpProvider', () => {
     expect(result.merklePathNodes[0].hash.value.toString('hex')).toEqual(
       '967f2a2c7f3d22f9278175c1e6aa39cf9171db91dceacd5ee0f37c2e507b5abe'
     );
-    const result1 = transform(transferInput,{},INPUT_TRANSFORMERS);
+    const result1 = transform(transferInput, {}, INPUT_TRANSFORMERS);
     expect(result1).toEqual({ merklePathNodes: undefined });
   });
   test('test transform with empty fieldsArray', async () => {
@@ -266,6 +266,18 @@ describe('test httpProvider', () => {
       },
     });
   });
+  test('test transformArrayToMap with Enum Array', async () => {
+    const dataType = AElf.pbjs.Root.fromJSON(tokenProto);
+    dataType.resolveAll();
+    const enumArray = dataType.lookupType('TestEnumArray');
+    const params = {
+      type: ['EMAIL', 'PHONE'],
+    };
+    const result = transformArrayToMap(enumArray, params);
+    expect(result).toEqual({
+      type: ['EMAIL', 'PHONE'],
+    });
+  });
   test('test encode address', async () => {
     const address =
       '0x967f2a2c7f3d22f9278175c1e6aa39cf9171db91dceacd5ee0f37c2e507b5abe';
@@ -332,11 +344,15 @@ describe('test httpProvider', () => {
     );
   });
   test('test output address transformer with array object origin', () => {
-    const address = [{
-      value: 'FXD7R7PHkfRn4fmEDvHCN+7hb2XD0NgAcxXjYkMccuY=',
-    }];
+    const address = [
+      {
+        value: 'FXD7R7PHkfRn4fmEDvHCN+7hb2XD0NgAcxXjYkMccuY=',
+      },
+    ];
     const result = OUTPUT_TRANSFORMERS[0].transformer(address);
-    expect(result).toEqual(['ASh2Wt7nSEmYqnGxPPzp4pnVDU4uhj1XW9Se5VeZcX2UDdyjx']);
+    expect(result).toEqual([
+      'ASh2Wt7nSEmYqnGxPPzp4pnVDU4uhj1XW9Se5VeZcX2UDdyjx',
+    ]);
   });
   test('test output hash transformer with string origin', () => {
     const address =
@@ -347,13 +363,15 @@ describe('test httpProvider', () => {
     );
   });
   test('test output hash transformer with array object origin', () => {
-    const address = [{
-      value: 'FXD7R7PHkfRn4fmEDvHCN+7hb2XD0NgAcxXjYkMccuY=',
-    }];
+    const address = [
+      {
+        value: 'FXD7R7PHkfRn4fmEDvHCN+7hb2XD0NgAcxXjYkMccuY=',
+      },
+    ];
     const result = OUTPUT_TRANSFORMERS[1].transformer(address);
-    expect(result).toEqual(
-      ['1570fb47b3c791f467e1f9840ef1c237eee16f65c3d0d8007315e362431c72e6']
-    );
+    expect(result).toEqual([
+      '1570fb47b3c791f467e1f9840ef1c237eee16f65c3d0d8007315e362431c72e6',
+    ]);
   });
   test('test output address transformer with object origin', () => {
     const address = {


### PR DESCRIPTION
Parsing can be problematic when the contract result contains an array of enumerated types